### PR TITLE
Elixir 1.0+ deps and requirements

### DIFF
--- a/lib/excetera/api.ex
+++ b/lib/excetera/api.ex
@@ -66,10 +66,10 @@ defmodule Excetera.API do
     timeout = Keyword.get(options, :timeout, default_timeout)
 
     case HTTPoison.request(type, url, body, headers, [timeout: timeout]) do
-      %HTTPoison.Response{status_code: code, body: body} when code in [200, 201] ->
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} when code in [200, 201] ->
         {:ok, decode_body(:ok, body, options)}
 
-      %HTTPoison.Response{status_code: 307} ->
+      {:ok, %HTTPoison.Response{status_code: 307}} ->
         # try again, die hard mode
         #
         # An etcd instance could be placed behind a proxy or a load balancer,
@@ -77,7 +77,7 @@ defmodule Excetera.API do
         # For this reason we are repeating the request at the same URL.
         request(type, url, headers, body, options)
 
-      %HTTPoison.Response{status_code: status, body: body} ->
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
         {:error, decode_body(:error, body, options) || status}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Excetera.Mixfile do
     [
       app: :excetera,
       version: "0.0.1",
-      elixir: "~> 0.14.0",
+      elixir: "~> 1.0.0",
       deps: deps
     ]
   end
@@ -20,8 +20,8 @@ defmodule Excetera.Mixfile do
 
   defp deps do
     [
-      {:httpoison, github: "edgurgel/httpoison"},
-      {:jazz, github: "meh/jazz"}
+      {:httpoison, "~> 0.5.0"},
+      {:jazz, "~> 0.2.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"hackney": {:git, "git://github.com/benoitc/hackney.git", "cf90543f9cc21ffea34d71035521b0102b8555cf", [ref: "cf90543f9cc21ffea34d71035521b0102b8555cf"]},
+%{"hackney": {:hex, :hackney, "0.14.3"},
   "hackney_lib": {:git, "https://github.com/benoitc/hackney_lib.git", "48a5a3fc64892c95e4e3efdd464f26ca5683d2f9", [tag: "0.3.0"]},
-  "httpoison": {:git, "git://github.com/edgurgel/httpoison.git", "75970fc5a6ba0429b53f38bc466cf77d76674976", []},
-  "idna": {:git, "git://github.com/benoitc/erlang-idna.git", "21aa158b7f36bf2a000f12fe40d7f21eece9cf65", [tag: "hackney-0.11.2"]},
-  "jazz": {:git, "git://github.com/meh/jazz.git", "d88a861644113b8ba335ff6a54fb059519566365", []}}
+  "httpoison": {:hex, :httpoison, "0.5.0"},
+  "idna": {:hex, :idna, "1.0.1"},
+  "jazz": {:hex, :jazz, "0.2.1"}}


### PR DESCRIPTION
Move towards Elixir 1.0+ and directly set version deps for recent version of HTTPoison and Jazz.
